### PR TITLE
updated intl dependency to support Flutter 3.32.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter_secure_storage: ^9.2.2
   http: ^1.2.2
   http_parser: ^4.0.2
-  intl: ^0.19.0
+  intl: ^0.20.2
   mime: ^2.0.0
   shared_preferences: ^2.3.2
 


### PR DESCRIPTION
This PR upgrades the `intl` package dependency to ^0.20.2 in response to the changes introduced in Flutter 3.32.0, which now requires intl >=0.20.2.

> Reference [Flutter 3.32.0 release notes](https://docs.flutter.dev/release/release-notes/release-notes-3.32.0)
